### PR TITLE
feat!: restructure CLI with render/gen subcommands and internal cleanup

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,1 +1,0 @@
-$pdflatex=q/xelatex -synctex=1 %O %S/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include src *.jinja
+recursive-include src *.yml

--- a/README.md
+++ b/README.md
@@ -8,21 +8,16 @@ Writes a [UK Standard Visitor](https://www.gov.uk/standard-visitor) visa invitat
 
 ### Requirements
 
-* Python 3 with pip
+* Python 3 with [pipx](https://pipx.pypa.io/)
 * LaTeX with OpenType font support, e.g. XeLaTeX, and latexmk
 
 ### Usage
 
-1. Install the package:
+1. Create a `data.yml` config file. Generate a starting template with:
+
 ```bash
-pip3 install uk-invitation-letter
+pipx run uk-invitation-letter gen > data.yml
 ```
-
-2. Configure latexmk:
-
-You can use your default setup or clone `.latexmkrc`.
-
-3. Create `data.yml` config file:
 
 Example:
 
@@ -70,9 +65,12 @@ docs:  # optional extra documents
   - table tennis match result sheet
 ```
 
-4. Run the generator:
+2. Render the letter:
 
 ```bash
-uk-invitation-letter --data data.yml --output invitation.pdf
+pipx run uk-invitation-letter render --data data.yml --output invitation.pdf
 ```
-The output will be saved to `invitation.pdf`.
+
+The output will be saved to `invitation.pdf`. Pass `--engine lualatex` if you prefer LuaLaTeX (default is XeLaTeX).
+
+For repeated use, install it once with `pipx install uk-invitation-letter` and then invoke `uk-invitation-letter render ...` directly.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-UK visa invitation letter generator [![PyPI](https://img.shields.io/pypi/v/uk-invitation-letter?style=flat-square)](https://pypi.org/project/uk-invitation-letter/)
-===
+# UK visa invitation letter generator [![PyPI](https://img.shields.io/pypi/v/uk-invitation-letter?style=flat-square)](https://pypi.org/project/uk-invitation-letter/)
 
 Writes a [UK Standard Visitor](https://www.gov.uk/standard-visitor) visa invitation letter for you.
 

--- a/src/invitation/builder.py
+++ b/src/invitation/builder.py
@@ -2,6 +2,7 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
+from typing import Final, Literal, get_args
 
 import jinja2
 from pydantic_yaml import parse_yaml_raw_as
@@ -9,24 +10,39 @@ from pydantic_yaml import parse_yaml_raw_as
 from .model import InvitationConfig
 from .util import date_format, fix_floating_punctuation, phone_format
 
+Engine = Literal["xelatex", "lualatex"]
+ENGINES: Final[tuple[Engine, ...]] = get_args(Engine)
 
-def build(config_file: pathlib.Path, output_file: pathlib.Path) -> None:
+
+def build(config_file: pathlib.Path, output_file: pathlib.Path, engine: Engine = "xelatex") -> None:
     config = parse_yaml_raw_as(InvitationConfig, config_file.read_text())
 
-    template_env = jinja2.Environment(loader=jinja2.PackageLoader("invitation", "templates"))
+    template_env = jinja2.Environment(
+        loader=jinja2.PackageLoader("invitation", "templates"),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
     template = template_env.get_template("invitation.tex.jinja")
     output_text = template.render(
-        **config.__dict__,
+        inviter=config.inviter,
+        invitee=config.invitee,
+        employer=config.employer,
+        embassy=config.embassy,
+        trip=config.trip,
+        docs=config.docs,
         date_format=date_format,
         phone_format=phone_format,
     )
     output_text = fix_floating_punctuation(output_text)
 
-    temp_dir = pathlib.Path(tempfile.mkdtemp())
-    tex_file = temp_dir / "invitation.tex"
-    pdf_file = temp_dir / "invitation.pdf"
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        temp_dir = pathlib.Path(temp_dir_name)
+        tex_file = temp_dir / "invitation.tex"
+        pdf_file = temp_dir / "invitation.pdf"
 
-    tex_file.write_text(output_text)
-    subprocess.call(["latexmk", "-pdf", f"-output-directory={temp_dir.absolute()}", tex_file.absolute()])
-
-    shutil.move(pdf_file, output_file)
+        tex_file.write_text(output_text)
+        subprocess.run(
+            ["latexmk", f"-{engine}", f"-output-directory={temp_dir}", tex_file],
+            check=True,
+        )
+        shutil.move(pdf_file, output_file)

--- a/src/invitation/builder.py
+++ b/src/invitation/builder.py
@@ -15,7 +15,7 @@ ENGINES: Final[tuple[Engine, ...]] = get_args(Engine)
 
 
 def build(config_file: pathlib.Path, output_file: pathlib.Path, engine: Engine = "xelatex") -> None:
-    config = parse_yaml_raw_as(InvitationConfig, config_file.read_text())
+    config = parse_yaml_raw_as(InvitationConfig, config_file.read_text(encoding="utf-8"))
 
     template_env = jinja2.Environment(
         loader=jinja2.PackageLoader("invitation", "templates"),
@@ -40,7 +40,7 @@ def build(config_file: pathlib.Path, output_file: pathlib.Path, engine: Engine =
         tex_file = temp_dir / "invitation.tex"
         pdf_file = temp_dir / "invitation.pdf"
 
-        tex_file.write_text(output_text)
+        tex_file.write_text(output_text, encoding="utf-8")
         subprocess.run(
             ["latexmk", f"-{engine}", f"-output-directory={temp_dir}", tex_file],
             check=True,

--- a/src/invitation/main.py
+++ b/src/invitation/main.py
@@ -3,7 +3,7 @@ import pathlib
 import sys
 
 from .builder import ENGINES, build
-from .template import TEMPLATE_YAML
+from .template import load_template_yaml
 
 
 def main() -> None:
@@ -21,7 +21,7 @@ def main() -> None:
     if args.command == "render":
         build(args.data, args.output, args.engine)
     elif args.command == "gen":
-        sys.stdout.write(TEMPLATE_YAML)
+        sys.stdout.write(load_template_yaml())
 
 
 if __name__ == "__main__":

--- a/src/invitation/main.py
+++ b/src/invitation/main.py
@@ -1,16 +1,27 @@
 import argparse
 import pathlib
+import sys
 
-from .builder import build
+from .builder import ENGINES, build
+from .template import TEMPLATE_YAML
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="uk-invitation-letter", description="Generate a UK invitation letter")
-    parser.add_argument("--data", type=pathlib.Path, help="Invitation data file path", required=True)
-    parser.add_argument("--output", type=pathlib.Path, help="Output path for the invitation", required=True)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    render = subparsers.add_parser("render", help="Render an invitation PDF from a data file")
+    render.add_argument("--data", type=pathlib.Path, required=True, help="Invitation data file path")
+    render.add_argument("--output", type=pathlib.Path, required=True, help="Output PDF path")
+    render.add_argument("--engine", choices=ENGINES, default="xelatex", help="LaTeX engine (default: xelatex)")
+
+    subparsers.add_parser("gen", help="Print a template data.yml to stdout")
 
     args = parser.parse_args()
-    build(args.data, args.output)
+    if args.command == "render":
+        build(args.data, args.output, args.engine)
+    elif args.command == "gen":
+        sys.stdout.write(TEMPLATE_YAML)
 
 
 if __name__ == "__main__":

--- a/src/invitation/model.py
+++ b/src/invitation/model.py
@@ -1,6 +1,7 @@
 import datetime
+from collections.abc import Sequence
 
-from pydantic import BaseModel, RootModel, model_validator
+from pydantic import BaseModel, Field, RootModel, model_validator
 
 from .util import and_join, use_non_breaking_space
 
@@ -14,14 +15,14 @@ class Address(RootModel):
             raise ValueError("Address must not be empty")
         return self
 
-    def __get_lines(self) -> list[str]:
-        return list(map(use_non_breaking_space, self.root))
+    def _lines(self) -> Sequence[str]:
+        return [use_non_breaking_space(line) for line in self.root]
 
     def line(self) -> str:
-        return ", ".join(self.__get_lines())
+        return ", ".join(self._lines())
 
     def multiline(self) -> str:
-        return "\\\\\n".join(self.__get_lines())
+        return "\\\\\n".join(self._lines())
 
 
 class Name(RootModel):
@@ -33,14 +34,14 @@ class Name(RootModel):
             raise ValueError("Name must not be empty")
         return self
 
-    def __as_list(self) -> list[str]:
+    def _as_sequence(self) -> Sequence[str]:
         return [self.root] if isinstance(self.root, str) else self.root
 
     def full_name(self) -> str:
-        return and_join(list(map(use_non_breaking_space, self.__as_list())))
+        return and_join([use_non_breaking_space(name) for name in self._as_sequence()])
 
     def short_name(self) -> str:
-        return and_join(list(map(lambda name: name.split(" ")[0], self.__as_list())))
+        return and_join([name.split(" ")[0] for name in self._as_sequence()])
 
 
 class Pronoun(RootModel):
@@ -52,17 +53,20 @@ class Pronoun(RootModel):
             raise ValueError("Pronouns must have three parts separated by `/`")
         return self
 
-    def __get_pronoun_part(self, idx: int, default: str) -> str:
+    def _part(self, idx: int, default: str) -> str:
         return self.root.split("/")[idx] if self.root else default
 
-    def get_subject(self) -> str:
-        return self.__get_pronoun_part(0, "they")
+    @property
+    def subject(self) -> str:
+        return self._part(0, "they")
 
-    def get_object(self) -> str:
-        return self.__get_pronoun_part(1, "them")
+    @property
+    def object(self) -> str:
+        return self._part(1, "them")
 
-    def get_determiner(self) -> str:
-        return self.__get_pronoun_part(2, "their")
+    @property
+    def determiner(self) -> str:
+        return self._part(2, "their")
 
 
 class Inviter(BaseModel):
@@ -76,7 +80,7 @@ class Inviter(BaseModel):
 
 class Invitee(BaseModel):
     name: Name
-    pronoun: Pronoun = Pronoun()
+    pronoun: Pronoun = Field(default_factory=Pronoun)
     relationship: str
 
 
@@ -105,4 +109,4 @@ class InvitationConfig(BaseModel):
     employer: Employer | None = None
     embassy: Embassy
     trip: Trip
-    docs: list[str] = []
+    docs: tuple[str, ...] = ()

--- a/src/invitation/template.py
+++ b/src/invitation/template.py
@@ -1,42 +1,5 @@
-from typing import Final
+from importlib import resources
 
-TEMPLATE_YAML: Final = """\
-inviter:
-  name: <full name>
-  address:
-    - <line 1>
-    - <line 2>
-  phone: "<GB phone number>"
-  email: <email>
-  residence: share code  # optional: `permit` / `share code` / `passport` / custom
-  proof_of_address: council tax bill  # optional
 
-employer:  # optional
-  name: <employer name>
-  address:
-    - <line 1>
-    - <line 2>
-
-embassy:
-  name: <embassy name>
-  address:
-    - <line 1>
-    - <line 2>
-
-invitee:
-  name:  # <first name> [<other names>]+ <last name>, use `~` for a non-breaking space
-    - <full name>
-  pronoun: null  # optional, they/them/their by default; otherwise e.g. she/her/her
-  relationship: friend
-
-trip:
-  arrival_date: YYYY-MM-DD
-  departure_date: YYYY-MM-DD
-  reason: a short trip  # optional
-  return_reason: to return home  # optional
-  return_country: <country>  # optional
-  financial_support: false
-
-docs:  # optional extra documents
-  - <document name>
-"""
+def load_template_yaml() -> str:
+    return resources.files("invitation").joinpath("template.yml").read_text(encoding="utf-8")

--- a/src/invitation/template.py
+++ b/src/invitation/template.py
@@ -1,0 +1,42 @@
+from typing import Final
+
+TEMPLATE_YAML: Final = """\
+inviter:
+  name: <full name>
+  address:
+    - <line 1>
+    - <line 2>
+  phone: "<GB phone number>"
+  email: <email>
+  residence: share code  # optional: `permit` / `share code` / `passport` / custom
+  proof_of_address: council tax bill  # optional
+
+employer:  # optional
+  name: <employer name>
+  address:
+    - <line 1>
+    - <line 2>
+
+embassy:
+  name: <embassy name>
+  address:
+    - <line 1>
+    - <line 2>
+
+invitee:
+  name:  # <first name> [<other names>]+ <last name>, use `~` for a non-breaking space
+    - <full name>
+  pronoun: null  # optional, they/them/their by default; otherwise e.g. she/her/her
+  relationship: friend
+
+trip:
+  arrival_date: YYYY-MM-DD
+  departure_date: YYYY-MM-DD
+  reason: a short trip  # optional
+  return_reason: to return home  # optional
+  return_country: <country>  # optional
+  financial_support: false
+
+docs:  # optional extra documents
+  - <document name>
+"""

--- a/src/invitation/template.yml
+++ b/src/invitation/template.yml
@@ -1,0 +1,41 @@
+# Starter template for uk-invitation-letter.
+# Replace the sample values with your own data.
+
+inviter:
+  name: Your Name  # use `~` for a non-breaking space, e.g. `John~H~Smith`
+  address:
+    - 123 Example Street
+    - Example City EC1A 1AA
+  phone: "07700900000"
+  email: you@example.com
+  residence: share code  # optional: `permit` / `share code` / `passport` / custom
+  proof_of_address: council tax bill  # optional
+
+employer:  # optional — delete this block if not applicable
+  name: Example Employer Ltd
+  address:
+    - 1 Office Road
+    - Example City EC2A 2BB
+
+embassy:
+  name: British Embassy Example
+  address:
+    - 1 Embassy Square
+    - Example City
+    - Example Country
+
+invitee:
+  name:  # <first name> [<other names>]+ <last name>
+    - Invitee Name
+  pronoun: null  # optional, they/them/their by default; otherwise e.g. she/her/her
+  relationship: friend
+
+trip:
+  arrival_date: 2026-01-01
+  departure_date: 2026-01-15
+  reason: a short trip  # optional
+  return_reason: null  # optional
+  return_country: null  # optional
+  financial_support: false
+
+docs: []  # optional: list of extra documents to enclose

--- a/src/invitation/templates/invitation.tex.jinja
+++ b/src/invitation/templates/invitation.tex.jinja
@@ -23,23 +23,19 @@
 {% block body %}
 \opening{Dear Visa Officer,}
 
-I would like to confirm that my {{ invitee.relationship }}, {{ invitee.name.full_name() }}, will apply for a UK visitor visa. {{ invitee.pronoun.get_subject().capitalize() }} will travel to the United~Kingdom from {{ date_format(trip.arrival_date) }} until {{ date_format(trip.departure_date) }}{% if trip.reason %} for {{ trip.reason }}{% endif %}.
+I would like to confirm that my {{ invitee.relationship }}, {{ invitee.name.full_name() }}, will apply for a UK visitor visa. {{ invitee.pronoun.subject.capitalize() }} will travel to the United~Kingdom from {{ date_format(trip.arrival_date) }} until {{ date_format(trip.departure_date) }}{% if trip.reason %} for {{ trip.reason }}{% endif %}.
 
 I am able to accommodate {{ invitee.name.short_name() }} at my place, {{ inviter.address.line() }}.
 {% if trip.financial_support %}
-{{ invitee.pronoun.get_subject().capitalize() }} will be in receipt of a return ticket and all of the expenses for {{ invitee.pronoun.get_determiner() }} journey will be met by me.
+{{ invitee.pronoun.subject.capitalize() }} will be in receipt of a return ticket and all of the expenses for {{ invitee.pronoun.determiner }} journey will be met by me.
 {% else %}
-{{ invitee.pronoun.get_subject().capitalize() }} will use {{ invitee.pronoun.get_determiner() }} savings for the trip, and I will assist {{ invitee.pronoun.get_object() }} to cover any additional expenses.
+{{ invitee.pronoun.subject.capitalize() }} will use {{ invitee.pronoun.determiner }} savings for the trip, and I will assist {{ invitee.pronoun.object }} to cover any additional expenses.
 {% endif %}
 
-While in the UK, {{ invitee.pronoun.get_subject() }} will not engage in gainful employment.
+While in the UK, {{ invitee.pronoun.subject }} will not engage in gainful employment.
 
 {% if trip.return_country or trip.return_reason %}
-After {{ invitee.pronoun.get_determiner() }} trip to the UK, {{ invitee.name.short_name() }} will {% if trip.return_country %} return to {{ trip.return_country }}{% else %} leave the UK {% endif %}{% if trip.return_reason %} {{ trip.return_reason }}{% endif %}.
-{% endif %}
-
-{% if trip.covid %}
-We are aware of the coronavirus guidelines, and we will respect them and re-plan the trip if necessary.
+After {{ invitee.pronoun.determiner }} trip to the UK, {{ invitee.name.short_name() }} will {% if trip.return_country %} return to {{ trip.return_country }}{% else %} leave the UK {% endif %}{% if trip.return_reason %} {{ trip.return_reason }}{% endif %}.
 {% endif %}
 
 {% if employer %}

--- a/src/invitation/util.py
+++ b/src/invitation/util.py
@@ -11,7 +11,7 @@ def and_join(strs: Sequence[str]) -> str:
     if len(strs) == 1:
         return strs[0]
     if len(strs) == 2:
-        return "{} and {}".format(strs[0], strs[1])
+        return f"{strs[0]} and {strs[1]}"
     return ", ".join(strs[:-1]) + ", and~" + strs[-1]
 
 
@@ -26,8 +26,8 @@ def phone_format(phone: str) -> str:
 
 
 def fix_floating_punctuation(s: str) -> str:
-    return re.sub(r" +([^\w\s])", r"\g<1>", s)
+    return re.sub(r" +([,.;:!?])", r"\g<1>", s)
 
 
 def use_non_breaking_space(s: str) -> str:
-    return re.sub(" ", "~", s)
+    return s.replace(" ", "~")


### PR DESCRIPTION
## Summary

- **New CLI shape**: `render` and `gen` subcommands.
  - `render --data data.yml --output invitation.pdf` (with optional `--engine lualatex`)
  - `gen` prints a starter `data.yml` template to stdout, loaded lazily from a packaged `template.yml`.
- **No more `.latexmkrc`**: pass `-xelatex` (or `-lualatex`) directly to latexmk, per latexmk best practice.
- **Install story**: README now recommends `pipx run` / `pipx install` instead of `pip3 install` (PEP 668 friendly).
- **Bug fixes**:
  - `subprocess.run(..., check=True)` so latex errors surface cleanly.
  - `TemporaryDirectory` context manager (no more leaked temp dirs).
  - Removed dead `{% if trip.covid %}` template block.
  - Narrowed `fix_floating_punctuation` regex so it no longer mangles ` -` or ` \$`.
  - Enabled Jinja `trim_blocks`/`lstrip_blocks`.
  - Explicit render kwargs instead of `**config.__dict__`.
- **Style**: single-underscore privates in `model.py`, pronoun getters → `@property`, `Field(default_factory=...)` for mutable defaults, `docs: tuple[str, ...] = ()` for immutable storage, `Final` engine list shared between CLI and builder.
- **Packaged template**: `src/invitation/template.yml` shipped as package data, loaded via `importlib.resources` only when `gen` runs. MANIFEST.in extended to match.

## Breaking change

`uk-invitation-letter --data ... --output ...` is now `uk-invitation-letter render --data ... --output ...`.

## Test plan

- [x] `ruff check` passes
- [x] `pyrefly check` passes (0 errors)
- [x] E2E: `uk-invitation-letter gen > /tmp/gen.yml && uk-invitation-letter render --data /tmp/gen.yml --output /tmp/gen.pdf` produces a valid PDF
- [x] Render with existing `data.yml` still produces a valid PDF via xelatex
- [ ] Manually verify output PDF content matches previous version (no regressions from Jinja whitespace trim or punctuation regex change)
- [ ] Try `--engine lualatex` on a machine with lualatex installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `gen` and `render` subcommands; `render` writes PDF (invitation.pdf) and accepts `--engine` (XeLaTeX default).

* **Improvements**
  * CLI refactor with clearer subcommands and engine selection.
  * Template loading added and a starter YAML template provided.

* **Documentation**
  * README updated to use pipx for install/run and show the new usage flow.

* **Chores**
  * Packaging now includes YAML templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->